### PR TITLE
update to gulp ^4.0.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,10 +73,10 @@ gulp.task("server", function() {
 })
 
 gulp.task("watch", function() {
-  gulp.watch("src/**/*.js", ["rollup"])
-  gulp.watch("examples/**/*.js", ["rollup"])
+  gulp.watch("src/**/*.js", gulp.series("rollup"))
+  gulp.watch("examples/**/*.js", gulp.series("rollup"))
 });
 
-gulp.task("dev", ["clean", "copy", "rollup", "server", "watch"]);
+gulp.task("dev", gulp.series("clean", gulp.parallel("copy", "rollup"), "server", "watch"));
 
-gulp.task("prod", ["clean", "rollup"]);
+gulp.task("prod", gulp.series("clean", "rollup"));

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",
     "eslint-plugin-react": "^7.8.2",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.2",
     "gulp-webserver": "^0.9.1",
     "highlight.js": "^9.12.0",
     "rollup": "^0.59.1",


### PR DESCRIPTION
This enables us to use higher versions of node for this library.

See https://stackoverflow.com/questions/55921442/how-to-fix-referenceerror-primordials-is-not-defined-in-node-js