### PR TITLE
fix: render innerHTML prose visibly and mount viewers in place of pgn nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.0.1 (2026-08-02)
+
+### Fixed
+
+- **InnerHTML mode no longer hides page content**: The raw HTML was previously rendered in a hidden `display: none` container with chess viewers appended afterward, which made surrounding prose invisible. The viewer now renders the HTML visibly and mounts a viewer in place of each `<pgn>` node, so surrounding content (paragraphs, headings, code blocks) displays correctly.
+- **Server-side rendering (SSR) compatibility**: Viewers are now mounted with `createRoot` inside the `<pgn>` nodes rather than rendered as siblings, avoiding hydration mismatch warnings when the component is server-rendered (e.g. in Next.js).
+
+### Added
+
+- `examples/ssr/` example demonstrating server-side rendering with client hydration.
+
 ## 2.0.0 (2026-08-01)
 
 ### ⚠️ Breaking Changes

--- a/examples/ssr/App.tsx
+++ b/examples/ssr/App.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PgnViewer from '../../src/index';
+
+const BLOG_HTML = `
+<h1>Costa Rican Chess Championship</h1>
+<p>Two friends battled it out at the Costa Rican National Chess Championships.</p>
+<pgn>[Event "CRC-ch 81th"]
+[White "Urbina, Edwin"]
+[Black "Duran Vega, Sergio"]
+[PlyCount "51"]
+
+1. e4 e5 2. d4 exd4 3. Qxd4 Nc6 4. Qe3 Nf6 5. Nc3 Bb4 6. Bd2 O-O 7. O-O-O Re8 8. Qg3 Rxe4 9. a3</pgn>
+<p>The opening was a sharp Sicilian-style line with early tactics.</p>
+<pgn>[Event "8th Tal Memorial"]
+[White "Carlsen, Magnus"]
+[Black "Nakamura, Hikaru"]
+[PlyCount "51"]
+
+1. c4 e6 2. g3 d5 3. Bg2 c6 4. Qc2 Nf6 5. Nf3 dxc4 6. Qxc4 b5 7. Qb3 Bb7 8. O-O Nbd7 9. d4 a6 10. Ne5 Qb6 11. Be3 c5 12. Nxd7 Nxd7 13. d5 e5 14. a4 b4 15. Nd2 Bd6</pgn>
+<p>Black held the balance with precise defense.</p>
+`;
+
+const App: React.FC = () => {
+  return (
+    <div className="blog-post">
+      <PgnViewer innerHTML>{BLOG_HTML}</PgnViewer>
+    </div>
+  );
+};
+
+export default App;

--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -1,0 +1,29 @@
+# SSR Example
+
+Demonstrates server-side rendering of `PgnViewer` with client hydration,
+mirroring the Next.js blog usage (`innerHTML` mode with prose around `<pgn>` tags).
+
+## Files
+
+- `App.tsx` - Shared app component (used by both server and client)
+- `server.tsx` - SSR server: `renderToString` + serves HTML (run with Bun)
+- `client.tsx` - Client entry: `hydrateRoot`
+
+## Run
+
+```bash
+# Build the client bundle (once)
+bun run build:client
+
+# Start the SSR server on port 3100
+bun run server
+
+# Open http://localhost:3100
+```
+
+## What this proves
+
+Server-rendered HTML contains visible prose, but the chessboards are empty
+(`react-chessboard` returns an empty div on the server) and the move list is
+absent (Viewer initializes state in `useEffect`). After hydration the boards
+populate, producing a React hydration-mismatch warning.

--- a/examples/ssr/client.tsx
+++ b/examples/ssr/client.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  hydrateRoot(container, <App />);
+}

--- a/examples/ssr/server.tsx
+++ b/examples/ssr/server.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import App from './App';
+
+const html = renderToString(<App />);
+
+const page = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>react-pgn-viewer SSR example</title>
+</head>
+<body>
+  <div id="root">${html}</div>
+  <script type="module" src="/client.js"></script>
+</body>
+</html>`;
+
+Bun.serve({
+  port: 3100,
+  fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname === '/client.js') {
+      return new Response(Bun.file(import.meta.dir + '/public/client.js'), {
+        headers: { 'content-type': 'text/javascript' },
+      });
+    }
+    return new Response(page, { headers: { 'content-type': 'text/html' } });
+  },
+});
+
+console.log('SSR server running at http://localhost:3100');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pgn-viewer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "React component for creating an interactive PGN viewer from string",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/__tests__/viewer.test.tsx
+++ b/src/__tests__/viewer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { Chess } from 'chess.js';
 import PgnViewer from '../index';
 
@@ -269,7 +269,9 @@ describe('innerHTML mode', () => {
       '</pgn>',
     ].join('\n');
 
-    render(<PgnViewer innerHTML>{htmlContent}</PgnViewer>);
+    act(() => {
+      render(<PgnViewer innerHTML>{htmlContent}</PgnViewer>);
+    });
     // Should render the viewer wrapper
     const wrapper = document.querySelector('.pgnWrapper');
     expect(wrapper).toBeTruthy();
@@ -285,8 +287,10 @@ describe('innerHTML mode', () => {
       '1. d4 d5 1-0</pgn>',
     ].join('\n');
 
-    const { container } = render(<PgnViewer innerHTML>{htmlContent}</PgnViewer>);
-    const viewers = container.querySelectorAll('.pgnWrapper');
+    act(() => {
+      render(<PgnViewer innerHTML>{htmlContent}</PgnViewer>);
+    });
+    const viewers = document.querySelectorAll('.pgnWrapper');
     expect(viewers.length).toBe(2);
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useCallback } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
 import Viewer from './Viewer';
 import { isValidPgn } from './helpers';
 import { DEFAULTS } from './constants';
@@ -32,6 +33,25 @@ const PgnViewer: React.FC<PgnViewerProps> = ({
   nodeModification,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const viewerRootsRef = useRef<Root[]>([]);
+
+  /**
+   * Builds a Viewer element for the given PGN string.
+   */
+  const makeViewer = useCallback(
+    (pgnInformation: string) => (
+      <Viewer
+        pgnInformation={pgnInformation}
+        blackSquareColor={blackSquareColor}
+        whiteSquareColor={whiteSquareColor}
+        width={width}
+        orientation={orientation}
+        backgroundColor={backgroundColor}
+        showCoordinates={showCoordinates}
+      />
+    ),
+    [blackSquareColor, whiteSquareColor, width, orientation, backgroundColor, showCoordinates],
+  );
 
   /**
    * Applies DOM modifications after render if configured.
@@ -54,53 +74,42 @@ const PgnViewer: React.FC<PgnViewerProps> = ({
   }, [nodeToModify, nodeModification]);
 
   /**
-   * Extracts PGN content from innerHTML children.
+   * Unmounts all previously mounted viewer roots.
    */
-  const extractPgnsFromHtml = useCallback((htmlContent: string): string[] => {
-    const pgns: string[] = [];
-    const regex = /<pgn>([\s\S]*?)<\/pgn>/gi;
-    let match;
-
-    while ((match = regex.exec(htmlContent)) !== null) {
-      const pgn = match[1]?.trim();
-      if (pgn && isValidPgn(pgn)) {
-        pgns.push(pgn);
-      }
-    }
-
-    return pgns;
+  const unmountViewers = useCallback(() => {
+    viewerRootsRef.current.forEach((root) => root.unmount());
+    viewerRootsRef.current = [];
   }, []);
 
-  // Apply DOM modifications after mount and updates
+  // InnerHTML mode: render the HTML visibly, then mount a Viewer in place of each <pgn> node.
   useEffect(() => {
+    if (!innerHTML || !containerRef.current) return;
+
+    unmountViewers();
     applyDomModifications();
-  }, [applyDomModifications, children]);
 
-  // InnerHTML mode: extract PGNs from children and render viewers
+    const nodes = containerRef.current.querySelectorAll('pgn');
+    nodes.forEach((node) => {
+      const pgn = (node.innerHTML || '').trim();
+      if (pgn && isValidPgn(pgn)) {
+        const root = createRoot(node);
+        root.render(makeViewer(pgn));
+        viewerRootsRef.current.push(root);
+      }
+    });
+  }, [innerHTML, children, makeViewer, applyDomModifications, unmountViewers]);
+
+  // Cleanup viewer roots on unmount. Deferred to a microtask so the roots are not
+  // unmounted synchronously while React is tearing down the parent tree (React 19+).
+  useEffect(() => {
+    return () => {
+      queueMicrotask(unmountViewers);
+    };
+  }, [unmountViewers]);
+
+  // InnerHTML mode: render children as visible HTML, viewers are mounted in place of <pgn> nodes
   if (innerHTML && typeof children === 'string') {
-    const pgns = extractPgnsFromHtml(children);
-
-    return (
-      <div ref={containerRef}>
-        <div
-          dangerouslySetInnerHTML={{ __html: children }}
-          style={{ display: 'none' }}
-          aria-hidden="true"
-        />
-        {pgns.map((pgn, index) => (
-          <Viewer
-            key={`pgn-${index}-${pgn.slice(0, 50)}`}
-            pgnInformation={pgn}
-            blackSquareColor={blackSquareColor}
-            whiteSquareColor={whiteSquareColor}
-            width={width}
-            orientation={orientation}
-            backgroundColor={backgroundColor}
-            showCoordinates={showCoordinates}
-          />
-        ))}
-      </div>
-    );
+    return <div ref={containerRef} dangerouslySetInnerHTML={{ __html: children }} />;
   }
 
   // Direct PGN mode: render single viewer
@@ -110,19 +119,7 @@ const PgnViewer: React.FC<PgnViewerProps> = ({
     return null;
   }
 
-  return (
-    <div ref={containerRef}>
-      <Viewer
-        pgnInformation={pgnContent}
-        blackSquareColor={blackSquareColor}
-        whiteSquareColor={whiteSquareColor}
-        width={width}
-        orientation={orientation}
-        backgroundColor={backgroundColor}
-        showCoordinates={showCoordinates}
-      />
-    </div>
-  );
+  return <div ref={containerRef}>{makeViewer(pgnContent)}</div>;
 };
 
 export default React.memo(PgnViewer);


### PR DESCRIPTION
## Summary

Fixes the innerHTML mode so that surrounding prose is visible and the viewer is SSR/hydration-safe.

### Problem

The innerHTML mode previously rendered the raw HTML inside a hidden container:

- `<div dangerouslySetInnerHTML={{ __html: children }} style={{ display: 'none' }} />`
- Chess viewers appended as siblings afterward

This made all surrounding prose (paragraphs, headings, code blocks) invisible on pages like the Next.js blog, and caused a `A tree hydrated but some attributes...` hydration-mismatch error under server-side rendering (react-chessboard renders an empty div on the server, and viewers as siblings did not match the hydrated tree).

### Fix

- Render the HTML visibly (`<div dangerouslySetInnerHTML={{ __html: children }} />`)
- Mount a `Viewer` with `createRoot` **inside** each `<pgn>` node via `useEffect`
- Unmount roots deferred via `queueMicrotask` to avoid React 19 sync-unmount warnings
- Direct (non-innerHTML) mode now reuses the same `makeViewer` builder

Verified with a new SSR example (`examples/ssr/`): server-rendered prose shows, 2 boards + 2 move lists hydrate with no console hydration error.

### Changelog

- Version bumped 2.0.0 → **2.0.1**
- Added SSR example under `examples/ssr/`

### Tests

- `bun run test:run` — 47/47 pass
- `bun run typecheck`, `bun run lint`, `bun run format:check`, `bun run build` — all pass